### PR TITLE
Added subjectAltName X509 ext so ATAK can use https://

### DIFF
--- a/atakofthecerts.py
+++ b/atakofthecerts.py
@@ -336,6 +336,15 @@ class AtakOfTheCerts:
         cert.add_extensions([
                              crypto.X509Extension(b"subjectKeyIdentifier", False, b"hash", subject=cert),
                              ])
+
+        # SAN is checked for https:// links
+        if common_name[:2].isnumeric():
+            subjectAltName = b"IP.1:"+common_name.encode()
+        else:
+            subjectAltName = b"DNS:"+common_name.encode()
+        cert.add_extensions([
+                             crypto.X509Extension(b'subjectAltName', False, subjectAltName)
+                             ])                             
         p12 = crypto.PKCS12()
         p12.set_privatekey(self.key)
         p12.set_certificate(cert)


### PR DESCRIPTION
If you use self-signed TAK server certs on a web server, ATAK will refuse to connect to the https:// URL which uses an IP address unless it has a sujectAltName extension in the certificate.

